### PR TITLE
add a home-manager module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "A tasty theme modification for Firefox 🦊";
+
+  outputs =
+    { self }:
+    {
+      homeModules = {
+        default = self.homeModules.parfait;
+        parfait = ./homeModule.nix;
+      };
+    };
+}

--- a/homeModule.nix
+++ b/homeModule.nix
@@ -1,0 +1,77 @@
+{ lib, ... }:
+let
+  perProfile =
+    f:
+    map
+      (variant: {
+        options.programs.${variant}.profiles = lib.mkOption {
+          type = lib.types.attrsOf (lib.types.submodule (f variant));
+        };
+      })
+      [
+        "firefox"
+        "librewolf"
+      ];
+
+  settings = lib.mkMerge [
+    # required settings
+    {
+      "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
+      "svg.context-properties.content.enabled" = true;
+      "sidebar.position_start" = true;
+    }
+    # parfait defaults
+    (lib.mapAttrs (_name: value: lib.mkOptionDefault value) {
+      "parfait.animations.enabled" = true;
+      "parfait.blur.enabled" = false;
+
+      "parfait.bg.accent-color" = false;
+      "parfait.bg.contrast" = 2;
+      "parfait.bg.gradient" = false;
+      "parfait.bg.opacity" = 4;
+      "parfait.bg.transparent" = false;
+
+      "parfait.tabs.groups.color" = false;
+
+      "parfait.sidebar.width.preset" = 2;
+
+      "parfait.theme.lwt.alt" = false;
+      "parfait.theme.roundness.preset" = 1;
+
+      "parfait.toolbar.sidebar-gutter" = true;
+      "parfait.toolbar.unified-sidebar" = true;
+
+      "parfait.traffic-lights.enabled" = false;
+      "parfait.traffic-lights.mono" = false;
+
+      "parfait.urlbar.url.center" = false;
+      "parfait.urlbar.results.compact" = false;
+      "parfait.urlbar.search-mode.glow" = true;
+
+      "parfait.window.borderless" = false;
+
+      "parfait.new-tab.logo" = 1;
+      "parfait.new-tab.bg.pattern" = false;
+    })
+  ];
+in
+{
+  imports = perProfile (
+    variant:
+    (
+      { config, ... }:
+      {
+        options.parfait.enable = lib.mkEnableOption "A tasty theme modification for ${lib.toUpper variant}";
+        config = lib.mkIf config.parfait.enable {
+          userChrome = ''
+            @import "${./parfait}/parfait.css";
+          '';
+          userContent = ''
+            @import "${./parfait}/pages.css";
+          '';
+          inherit settings;
+        };
+      }
+    )
+  );
+}


### PR DESCRIPTION
allows user's of [home-mannager](https://github.com/nix-community/home-manager/) to install this theme very easily:
```diff
diff --git a/flake.nix b/flake.nix
index aaeb132..805daa5 100644
--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,8 @@
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    parfait.url = "github:reizumii/parfait";
   };
 
   outputs =
diff --git a/home.nix b/home.nix
index c00b39f..60eae66 100644
--- a/home.nix
+++ b/home.nix
@@ -1,5 +1,7 @@
 { pkgs, inputs, ... }:
 {
+  imports = [ inputs.parfait.homeModules.parfait ];
+
   home.username = "jdoe";
   home.homeDirectory = "/home/jdoe";
 
@@ -11,6 +13,7 @@
   programs.firefox = {
     enable = true;
     profiles.default = {
+      parfait.enable = true;
       settings = {
         "privacy.resistFingerprinting" = false;
         "privacy.clearOnShutdown.history" = false;
```

> [!NOTE]
> Any future updates to `user.js` should be reflected in the `settings` deceleration in `homeModule.nix`